### PR TITLE
Add truncated normal drift variant of RDM functions

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -31,6 +31,38 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// dWald_tnorm
+NumericVector dWald_tnorm(NumericVector t, NumericVector mu, NumericVector sd2, NumericVector B, NumericVector A, NumericVector t0);
+RcppExport SEXP _EMC2_dWald_tnorm(SEXP tSEXP, SEXP muSEXP, SEXP sd2SEXP, SEXP BSEXP, SEXP ASEXP, SEXP t0SEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericVector >::type t(tSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type mu(muSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type sd2(sd2SEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type B(BSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type A(ASEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type t0(t0SEXP);
+    rcpp_result_gen = Rcpp::wrap(dWald_tnorm(t, mu, sd2, B, A, t0));
+    return rcpp_result_gen;
+END_RCPP
+}
+// pWald_tnorm
+NumericVector pWald_tnorm(NumericVector t, NumericVector mu, NumericVector sd2, NumericVector B, NumericVector A, NumericVector t0);
+RcppExport SEXP _EMC2_pWald_tnorm(SEXP tSEXP, SEXP muSEXP, SEXP sd2SEXP, SEXP BSEXP, SEXP ASEXP, SEXP t0SEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericVector >::type t(tSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type mu(muSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type sd2(sd2SEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type B(BSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type A(ASEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type t0(t0SEXP);
+    rcpp_result_gen = Rcpp::wrap(pWald_tnorm(t, mu, sd2, B, A, t0));
+    return rcpp_result_gen;
+END_RCPP
+}
 // calculate_subject_means
 arma::mat calculate_subject_means(const Rcpp::List& group_designs, const arma::colvec& params, const int n_subjects, const int n_pars);
 RcppExport SEXP _EMC2_calculate_subject_means(SEXP group_designsSEXP, SEXP paramsSEXP, SEXP n_subjectsSEXP, SEXP n_parsSEXP) {
@@ -495,6 +527,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_EMC2_plba", (DL_FUNC) &_EMC2_plba, 6},
     {"_EMC2_dWald", (DL_FUNC) &_EMC2_dWald, 5},
     {"_EMC2_pWald", (DL_FUNC) &_EMC2_pWald, 5},
+    {"_EMC2_dWald_tnorm", (DL_FUNC) &_EMC2_dWald_tnorm, 6},
+    {"_EMC2_pWald_tnorm", (DL_FUNC) &_EMC2_pWald_tnorm, 6},
     {"_EMC2_pEXG", (DL_FUNC) &_EMC2_pEXG, 6},
     {"_EMC2_dEXG", (DL_FUNC) &_EMC2_dEXG, 5},
     {"_EMC2_dEXGrace", (DL_FUNC) &_EMC2_dEXGrace, 4},

--- a/src/model_RDM.h
+++ b/src/model_RDM.h
@@ -109,6 +109,67 @@ double digt(double t, double k = 1., double l = 1., double a = .1, double thresh
   return pdf;
 }
 
+// Wald density with drift sampled from a truncated normal distribution
+double digt_tnorm(double t, double k = 1., double mu = 1., double sd2 = 1.,
+                  double a = .1, double threshold = 1e-10){
+  if (t <= 0.){
+    return 0.;
+  }
+  // ignore start point variability if smaller than threshold
+  if (a < threshold){
+    double lambda = 1.;
+    double denom = R::pnorm(mu / std::sqrt(sd2), 0., 1., true, false);
+    if (denom == 0.) return 0.;
+    double num = k * std::sqrt(lambda / (2. * M_PI * std::pow(t,3) * (lambda * t * sd2 + 1.)));
+    double exp_term = std::exp(- (lambda * std::pow(mu * t - k,2)) /
+                          (2. * t * (lambda * t * sd2 + 1.)));
+    double pn = R::pnorm((lambda * k * sd2 + mu) /
+                         std::sqrt(lambda * t * sd2 * sd2 + sd2), 0., 1., true, false);
+    return num / denom * exp_term * pn;
+  } else {
+    // crude numerical integration over start point variability
+    int steps = 10;
+    double h = (2. * a) / steps;
+    double sum = 0.;
+    for(int i = 0; i <= steps; i++){
+      double alpha = k - a + h * i;
+      double lambda = 1.;
+      double denom = R::pnorm(mu / std::sqrt(sd2), 0., 1., true, false);
+      if (denom == 0.) continue;
+      double num = alpha * std::sqrt(lambda / (2. * M_PI * std::pow(t,3) * (lambda * t * sd2 + 1.)));
+      double exp_term = std::exp(- (lambda * std::pow(mu * t - alpha,2)) /
+                            (2. * t * (lambda * t * sd2 + 1.)));
+      double pn = R::pnorm((lambda * alpha * sd2 + mu) /
+                           std::sqrt(lambda * t * sd2 * sd2 + sd2), 0., 1., true, false);
+      double weight = (i==0 || i==steps) ? 0.5 : 1.0;
+      sum += weight * (num / denom * exp_term * pn);
+    }
+  return h * sum / (2. * a);
+  }
+}
+
+// numerical cdf based on digt_tnorm
+double pigt_tnorm(double t, double k = 1., double mu = 1., double sd2 = 1.,
+                  double a = .1, int steps = 100){
+  if (t <= 0.) return 0.;
+  double h = t / steps;
+  double sum = 0.;
+  for(int i = 0; i <= steps; i++){
+    double ti = h * i;
+    double weight = (i==0 || i==steps) ? 0.5 : 1.0;
+    sum += weight * digt_tnorm(ti, k, mu, sd2, a);
+  }
+  return h * sum;
+}
+
+// prototypes for truncated normal drift wrappers
+NumericVector dWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0);
+NumericVector pWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0);
+
 
 NumericVector drdm_c(NumericVector rts, NumericMatrix pars, LogicalVector idx, double min_ll, LogicalVector is_ok){
   //v = 0, B = 1, A = 2, t0 = 3, s = 4

--- a/src/model_RDM_tnorm.cpp
+++ b/src/model_RDM_tnorm.cpp
@@ -1,0 +1,55 @@
+#include <Rcpp.h>
+#include <cmath>
+
+using namespace Rcpp;
+
+// forward declarations of density functions implemented in model_RDM.h
+double digt_tnorm(double t, double k = 1., double mu = 1., double sd2 = 1.,
+                  double a = .1, double threshold = 1e-10);
+double pigt_tnorm(double t, double k = 1., double mu = 1., double sd2 = 1.,
+                  double a = .1, int steps = 100);
+
+// Implementation of the truncated normal drift versions
+
+NumericVector dWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0);
+NumericVector pWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0);
+
+// include function definitions from header (not inline)
+
+// [[Rcpp::export]]
+NumericVector dWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0){
+  int n = t.size();
+  NumericVector pdf(n);
+  for (int i = 0; i < n; i++){
+    t[i] = t[i] - t0[i];
+    if (t[i] <= 0){
+      pdf[i] = 0.;
+    } else {
+      pdf[i] = digt_tnorm(t[i], B[i] + .5 * A[i], mu[i], sd2[i], .5 * A[i]);
+    }
+  }
+  return pdf;
+}
+
+// [[Rcpp::export]]
+NumericVector pWald_tnorm(NumericVector t, NumericVector mu,
+                          NumericVector sd2, NumericVector B,
+                          NumericVector A, NumericVector t0){
+  int n = t.size();
+  NumericVector cdf(n);
+  for (int i = 0; i < n; i++){
+    t[i] = t[i] - t0[i];
+    if (t[i] <= 0){
+      cdf[i] = 0.;
+    } else {
+      cdf[i] = pigt_tnorm(t[i], B[i] + .5 * A[i], mu[i], sd2[i], .5 * A[i]);
+    }
+  }
+  return cdf;
+}


### PR DESCRIPTION
## Summary
- implement digt_tnorm and pigt_tnorm for truncated normal drift
- add exported C++ wrappers dWald_tnorm and pWald_tnorm
- expose new functions via RcppExports

## Testing
- `R CMD INSTALL .` (fails without network; succeeded after modifications)
- `devtools::test()` (fails: Rcpp errors)

------
https://chatgpt.com/codex/tasks/task_e_685be2e2fc88832abf5fd103ba321aa4