### PR TITLE
⚡ Bolt: Replace std::pow with multiplication in C++ math loops

### DIFF
--- a/src/model_SS_EXG.h
+++ b/src/model_SS_EXG.h
@@ -528,7 +528,8 @@ NumericVector pEXG_old(NumericVector q,
     if (!traits::is_infinite<REALSXP>(q[i])){
       //      if (tau > .05 * sigma){
       double z_i = q[i] - mu - (sigma * sigma) / tau;
-      cdf[i] = R::pnorm((q[i] - mu) / sigma, 0., 1., true, false) - std::exp(std::log(R::pnorm(z_i / sigma, 0., 1., true, false)) + (std::pow((mu + (sigma * sigma / tau)), 2) - mu * mu - 2. * q[i] * (sigma * sigma / tau)) / (2. * sigma * sigma));
+      double mu_term = mu + (sigma * sigma / tau);
+      cdf[i] = R::pnorm((q[i] - mu) / sigma, 0., 1., true, false) - std::exp(std::log(R::pnorm(z_i / sigma, 0., 1., true, false)) + (mu_term * mu_term - mu * mu - 2. * q[i] * (sigma * sigma / tau)) / (2. * sigma * sigma));
       //      } else {
       //        cdf[i] = R::pnorm(q[i], mu, sigma, true, false);
       //      }

--- a/src/model_SS_RDEX.h
+++ b/src/model_SS_RDEX.h
@@ -278,7 +278,8 @@ NumericVector pEXG_RDEX(NumericVector q,
     if (!traits::is_infinite<REALSXP>(q[i])){
       if (tau > .05 * sigma){
         double z_i = q[i] - mu - (sigma * sigma) / tau;
-        cdf[i] = R::pnorm((q[i] - mu) / sigma, 0., 1., true, false) - std::exp(std::log(R::pnorm(z_i / sigma, 0., 1., true, false)) + (std::pow((mu + (sigma * sigma / tau)), 2) - mu * mu - 2. * q[i] * (sigma * sigma / tau)) / (2. * sigma * sigma));
+        double mu_term = mu + (sigma * sigma / tau);
+        cdf[i] = R::pnorm((q[i] - mu) / sigma, 0., 1., true, false) - std::exp(std::log(R::pnorm(z_i / sigma, 0., 1., true, false)) + (mu_term * mu_term - mu * mu - 2. * q[i] * (sigma * sigma / tau)) / (2. * sigma * sigma));
       } else {
         cdf[i] = R::pnorm(q[i], mu, sigma, true, false);
       }

--- a/src/trend.h
+++ b/src/trend.h
@@ -271,17 +271,20 @@ NumericMatrix run_kernel_rcpp(NumericMatrix kernel_pars,
         } else if (kernel == "poly2") {
           for (int i = 0; i < n_comp; ++i) if (good[i]) {
             int r = good_pos[i];
-            comp_out[i] = kp_good(r, 0) * cov_comp[i] + kp_good(r, 1) * std::pow(cov_comp[i], 2);
+            double x = cov_comp[i];
+            comp_out[i] = x * (kp_good(r, 0) + x * kp_good(r, 1));
           }
         } else if (kernel == "poly3") {
           for (int i = 0; i < n_comp; ++i) if (good[i]) {
             int r = good_pos[i];
-            comp_out[i] = kp_good(r, 0) * cov_comp[i] + kp_good(r, 1) * std::pow(cov_comp[i], 2) + kp_good(r, 2) * std::pow(cov_comp[i], 3);
+            double x = cov_comp[i];
+            comp_out[i] = x * (kp_good(r, 0) + x * (kp_good(r, 1) + x * kp_good(r, 2)));
           }
         } else if (kernel == "poly4") {
           for (int i = 0; i < n_comp; ++i) if (good[i]) {
             int r = good_pos[i];
-            comp_out[i] = kp_good(r, 0) * cov_comp[i] + kp_good(r, 1) * std::pow(cov_comp[i], 2) + kp_good(r, 2) * std::pow(cov_comp[i], 3) + kp_good(r, 3) * std::pow(cov_comp[i], 4);
+            double x = cov_comp[i];
+            comp_out[i] = x * (kp_good(r, 0) + x * (kp_good(r, 1) + x * (kp_good(r, 2) + x * kp_good(r, 3))));
           }
         } else {
           stop("Unknown kernel type");

--- a/src/wald_functions.h
+++ b/src/wald_functions.h
@@ -58,8 +58,8 @@ double pigt(double t, double k = 1, double l = 1, double a = .1, double threshol
 
     cdf = 1. + std::exp(t6a) - std::exp(t6b) + ((- k + a) * t5a - (k - a) * t5b) / (2. * a);
   } else {
-    double t1a = std::exp(- .5 * std::pow(k - a - t * l, 2) / t);
-    double t1b = std::exp(- .5 * std::pow(a + k - t * l, 2) / t);
+    double t1a = std::exp(- .5 * (k - a - t * l) * (k - a - t * l) / t);
+    double t1b = std::exp(- .5 * (a + k - t * l) * (a + k - t * l) / t);
     double t1 = std::exp(.5* (lgt - M_LN2 - L_PI)) * (t1a - t1b);
 
     double t2a = std::exp(2. * l * (k - a) + R::pnorm(- (k - a + t * l) / sqt, 0., 1., true, true));
@@ -92,8 +92,8 @@ double digt(double t, double k = 1., double l = 1., double a = .1, double thresh
   } else {
     double sqt = std::sqrt(t);
 
-    double t1a = - std::pow(a - k + t * l, 2) / (2. * t);
-    double t1b = - std::pow(a + k - t * l, 2) / (2. * t);
+    double t1a = - (a - k + t * l) * (a - k + t * l) / (2. * t);
+    double t1b = - (a + k - t * l) * (a + k - t * l) / (2. * t);
     double t1 = M_SQRT1_2 * (std::exp(t1a) - std::exp(t1b)) / (std::sqrt(M_PI) * sqt);
 
     double t2a = 2. * R::pnorm((- k + a) / sqt + sqt * l, 0., 1., true, false) - 1.;


### PR DESCRIPTION
💡 What: Replaced usages of `std::pow(x, 2)` with `x * x` and simplified polynomial evaluation using Horner's method in C++ source files (`src/trend.h`, `src/wald_functions.h`, `src/model_SS_EXG.h`, `src/model_SS_RDEX.h`).

🎯 Why: `std::pow(x, 2)` calls the full generalized `pow` function, which performs complex condition checks and float math operations. Using simple multiplication `x * x` requires significantly fewer CPU cycles. Horner's method similarly reduces the total number of floating point multiplications and additions from $O(n^2)$ to $O(n)$. These functions reside in hot loops evaluating PDFs and CDFs where performance impact adds up.

📊 Impact: Reduces constant overhead per iteration in the hot loops that evaluate probability density, cumulative distribution and trends, expected to yield a measurable speedup for models utilizing these mathematical components.

🔬 Measurement: Verify by executing benchmarks on Rcpp models measuring execution time for large datasets.

---
*PR created automatically by Jules for task [5728272112294639591](https://jules.google.com/task/5728272112294639591) started by @Howchie*