### PR TITLE
⚡ Bolt: [performance improvement] Vectorize R apply calls

### DIFF
--- a/R/SBC.R
+++ b/R/SBC.R
@@ -208,9 +208,9 @@ calc_sbc_stats <- function(stats){
   out_names <- names(stats[[1]])
   for(i in 1:length(stats[[1]])){
     out[[out_names[i]]] <- list(
-      coverage = apply(stats$coverage[[i]], 2, mean),
+      coverage = colMeans(stats$coverage[[i]]),
       # precision = apply(stats$med[[i]], 2, sd),
-      bias = apply(stats$bias[[i]], 2, mean)
+      bias = colMeans(stats$bias[[i]])
     )
   }
   return(out)

--- a/R/model_LBA.R
+++ b/R/model_LBA.R
@@ -144,8 +144,8 @@ rLBA <- function(lR,pars,p_types=c("v","sv","b","A","t0"),
   dt[ok] <- (pars[,"b"]-pars[,"A"]*runif(dim(pars)[1]))/
     msm::rtnorm(dim(pars)[1],pars[,"v"],pars[,"sv"],ifelse(posdrift,0,-Inf))
   dt[dt<0] <- Inf
-  bad <- apply(dt,2,function(x){all(is.infinite(x))})
-  R <- apply(dt,2,which.min)
+  bad <- colSums(is.infinite(dt)) == nrow(dt)
+  R <- max.col(-t(dt), ties.method='first')
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   # Any t0 difference with lR due to response production time (no effect on race)
   rt <- matrix(t0,nrow=nr)[pick] + dt[pick]

--- a/R/model_LNR.R
+++ b/R/model_LNR.R
@@ -26,7 +26,7 @@ rLNR <- function(lR,pars,p_types=c("m","s","t0"),ok=rep(TRUE,dim(pars)[1])){
   t0 <- pars[,"t0"]
   pars <- pars[ok,]
   dt[ok] <- stats::rlnorm(dim(pars)[1],meanlog=pars[,"m"],sdlog=pars[,"s"])
-  R <- apply(dt,2,which.min)
+  R <- max.col(-t(dt), ties.method='first')
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   # Any t0 difference with lR due to response production time (no effect on race)
   rt <- matrix(t0,nrow=nr)[pick] + dt[pick]

--- a/R/model_RDM.R
+++ b/R/model_RDM.R
@@ -94,7 +94,7 @@ rRDM <- function(lR,pars,p_types=c("v","B","A","t0"),ok=rep(TRUE,dim(pars)[1]))
   t0 <- pars[,"t0"]
   pars <- pars[ok,]
   dt[ok] <- rWald(sum(ok),B=pars[,"B"],v=pars[,"v"],A=pars[,"A"])
-  R <- apply(dt,2,which.min)
+  R <- max.col(-t(dt), ties.method='first')
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   # Any t0 difference with lR due to response production time (no effect on race)
   rt <- matrix(t0,nrow=nr)[pick] + dt[pick]

--- a/R/model_SS.R
+++ b/R/model_SS.R
@@ -399,7 +399,7 @@ rexGaussian <- function(lR,pars,p_types=c("mu","sigma","tau"),
     stop("pars must have columns ",paste(p_types,collapse = " "))
   dt <- matrix(rexG(dim(pars)[1],pars[,"mu"],pars[,"sigma"],pars[,"tau"]),
                nrow=length(levels(lR)))
-  R <- apply(dt,2,which.min)
+  R <- max.col(-t(dt), ties.method='first')
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   rt <- dt[pick]
   R <- factor(levels(lR)[R],levels=levels(lR))
@@ -543,10 +543,10 @@ rSSexGaussian <- function(data,pars,ok=rep(TRUE,dim(pars)[1]))
   R <- rt <- rep(NA,ntrials)
   
   # All accumulators Inf (usually when both gf and tf)
-  allinf <- apply(dt,2,function(x)all(is.infinite(x)))
+  allinf <- colSums(is.infinite(dt)) == nrow(dt)
   
   # get winner of stop and go where there is a race
-  r <- c(0, acc)[apply(dt[,!allinf,drop=FALSE],2,which.min)]
+  r <- c(0, acc)[max.col(-t(dt[,!allinf,drop=FALSE]), ties.method='first')]
   
   # stop wins
   stopwins <- r==0
@@ -565,7 +565,7 @@ rSSexGaussian <- function(data,pars,ok=rep(TRUE,dim(pars)[1]))
     # stop triggered accumulators that are racing
     rst <- dt[-1,!allinf,drop=FALSE][accST,stopwins,drop=FALSE]
     # stop-triggered winners
-    rtw <- apply(rst,2,which.min)
+    rtw <- max.col(-t(rst), ties.method='first')
     # index for stop-triggered
     R[!allinf][stopwins] <- accST[rtw]
     pick <- cbind(rtw,1:ncol(rst))
@@ -917,10 +917,10 @@ rSShybrid <- function(data,pars,ok=rep(TRUE,dim(pars)[1]))
   R <- rt <- rep(NA,ntrials)
   
   # All accumulators Inf (usually when both gf and tf)
-  allinf <- apply(dt,2,function(x)all(is.infinite(x)))
+  allinf <- colSums(is.infinite(dt)) == nrow(dt)
   
   # get winner of stop and go where there is a race
-  r <- c(0, acc)[apply(dt[,!allinf,drop=FALSE],2,which.min)]
+  r <- c(0, acc)[max.col(-t(dt[,!allinf,drop=FALSE]), ties.method='first')]
   
   # stop wins
   stopwins <- r==0
@@ -939,7 +939,7 @@ rSShybrid <- function(data,pars,ok=rep(TRUE,dim(pars)[1]))
     # stop triggered accumulators that are racing
     rst <- dt[-1,!allinf,drop=FALSE][accST,stopwins,drop=FALSE]
     # stop-triggered winners
-    rtw <- apply(rst,2,which.min)
+    rtw <- max.col(-t(rst), ties.method='first')
     # index for stop-triggered
     R[!allinf][stopwins] <- accST[rtw]
     pick <- cbind(rtw,1:ncol(rst))


### PR DESCRIPTION
💡 What: Replaced slow row-wise/column-wise `apply()` operations on matrices with highly optimized C-backed primitives (`max.col`, `colSums`, `colMeans`) across `R/model_LBA.R`, `R/model_LNR.R`, `R/model_RDM.R`, `R/model_SS.R`, and `R/SBC.R`.
🎯 Why: In R, `apply()` on matrices invokes an implicit loop and can be incredibly slow. For model generation and simulation files called repeatedly, this creates a major bottleneck. Replacing `apply(dt, 2, which.min)` with `max.col(-t(dt), ties.method='first')`, `apply(dt, 2, function(x) all(is.infinite(x)))` with `colSums(is.infinite(dt)) == nrow(dt)`, and `apply(..., 2, mean)` with `colMeans(...)` eliminates function call overhead and leverages highly optimized internal C loops.
📊 Impact: Expected massive speedups during data generation and parameter simulation/SBC evaluation.
🔬 Measurement: Run a local simulation with these updated packages vs main. Note the time reduction during generating samples or data via standard `microbenchmark` profiling.

---
*PR created automatically by Jules for task [15622615419397750769](https://jules.google.com/task/15622615419397750769) started by @Howchie*