### PR TITLE
⚡ Bolt: [performance improvement] Vectorize string concatenation in plot functions

### DIFF
--- a/R/design_plot.R
+++ b/R/design_plot.R
@@ -7,9 +7,7 @@ combine_factors <- function(df, factor_names, new_col_name) {
     df[[new_col_name]] <- "global"
     return(df)
   }
-  df[[new_col_name]] <- apply(df[, factor_names, drop=FALSE], 1, function(rowvals) {
-    paste(rowvals, collapse=":")
-  })
+  df[[new_col_name]] <- do.call(paste, c(unname(as.data.frame(df[, factor_names, drop=FALSE])), sep=":"))
   return(df)
 }
 
@@ -89,9 +87,7 @@ get_defect_scalars <- function(
   if (length(plot_cols_union) == 0) {
     cells <- rep("global", nrow(data))
   } else {
-    cells <- apply(data[, plot_cols_union, drop=FALSE], 1, function(r) {
-      paste(r, collapse=" ")
-    })
+    cells <- do.call(paste, c(unname(as.data.frame(data[, plot_cols_union, drop=FALSE])), sep=" "))
   }
   unique_cells <- unique(cells)
 
@@ -255,9 +251,7 @@ single_DDM_plot <- function(
     if (length(cols_in_data)==0) {
       row_cells <- rep("global", nrow(dat))
     } else {
-      row_cells <- apply(dat[,cols_in_data,drop=FALSE], 1, function(r) {
-        paste(r, collapse=" ")
-      })
+      row_cells <- do.call(paste, c(unname(as.data.frame(dat[, cols_in_data, drop=FALSE])), sep=" "))
     }
     unique_cells <- unique(row_cells)
 
@@ -546,9 +540,7 @@ single_race_plot <- function(
   if(length(cols_in_data)==0) {
     row_cells <- rep("global",nrow(data_sub))
   } else {
-    row_cells <- apply(data_sub[,cols_in_data,drop=FALSE],1,function(r){
-      paste(r,collapse=" ")
-    })
+    row_cells <- do.call(paste, c(unname(as.data.frame(data_sub[, cols_in_data, drop=FALSE])), sep=" "))
   }
   unique_cells <- unique(row_cells)
 
@@ -819,9 +811,7 @@ single_LNR_plot <- function(
   if (length(cols_in_data) == 0) {
     row_cells <- rep("global", nrow(data_sub))
   } else {
-    row_cells <- apply(data_sub[, cols_in_data, drop=FALSE], 1, function(r) {
-      paste(r, collapse=" ")
-    })
+    row_cells <- do.call(paste, c(unname(as.data.frame(data_sub[, cols_in_data, drop=FALSE])), sep=" "))
   }
   unique_cells <- unique(row_cells)
 

--- a/R/plot_data.R
+++ b/R/plot_data.R
@@ -1,7 +1,7 @@
 create_group_key <- function(df, factors) {
   if (length(factors) == 0) return(rep("All Data", nrow(df)))
-  key <- apply(df[, factors, drop = FALSE], 1, function(x)
-    paste(paste(factors, x, sep = "="), collapse = " "))
+  formatted_cols <- lapply(factors, function(f) paste(f, df[[f]], sep = "="))
+  key <- do.call(paste, c(formatted_cols, sep = " "))
   levs <- lapply(df[,factors],levels)
   for (i in 1:length(factors)) levs[[i]] <- paste(factors[i],levs[[i]],sep="=")
   lev <- levs[[1]]


### PR DESCRIPTION
💡 **What**: Replaced `apply(..., 1, function(x) paste(..., collapse=" "))` with `do.call(paste, c(unname(as.data.frame(...)), sep=" "))` across 6 locations in `R/design_plot.R` and `R/plot_data.R` for cell/group key generation.

🎯 **Why**: `apply(MARGIN=1)` on a data frame internally coerces the entire data frame to a matrix, converting all columns to characters, before iterating over each row. This is notoriously slow. Vectorized `do.call(paste, ...)` operates column-by-column, bypassing the coercion penalty and eliminating R-level loop overhead.

📊 **Impact**: Expected to significantly speed up plot generation and data aggregation functions (`plot_density`, `single_race_plot`, etc.) on large datasets, reducing plotting time.

🔬 **Measurement**: The impact can be verified by running the plot functions on a dataset with >10,000 rows. The optimized `do.call` pattern typically yields a >5x speedup for string concatenation over `apply`.

---
*PR created automatically by Jules for task [10375969227956531747](https://jules.google.com/task/10375969227956531747) started by @Howchie*