### PR TITLE
Provide missing defaults for LC/LT/UC/UT

### DIFF
--- a/src/particle_ll.cpp
+++ b/src/particle_ll.cpp
@@ -1339,7 +1339,6 @@ double c_log_likelihood_race(
   GslWorkspacePtr workspace(nullptr, &gsl_integration_workspace_free);
   
   // Fetch censoring and truncation values from dadm columns. These are passed across all rows for ease of access, but should be identical at least at the subject level as they don't correspond to a data entry. Attributes probably a better fit here but clunky.
-  // todo fill with defaults if missing for backwards compatability (LC/LT=0, UC/UT=R_PosInf)
   Rcpp::NumericVector LT = get_col_with_default(dadm, "LT", 0.0);
   Rcpp::NumericVector UT = get_col_with_default(dadm, "UT", R_PosInf);
   Rcpp::NumericVector LC = get_col_with_default(dadm, "LC", 0.0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -213,9 +213,28 @@ Rcpp::NumericVector lnr_pfun_adapter(Rcpp::NumericVector rt,
 }
 
 // Helper to safely get a column from a DataFrame with a default value if missing
+// Also fills NA values with the default for backward compatibility.
 inline Rcpp::NumericVector get_col_with_default(const Rcpp::DataFrame& df, const std::string& name, double default_val) {
   if (df.containsElementNamed(name.c_str())) {
-    return df[name];
+    Rcpp::NumericVector col = df[name];
+    // Check for NAs and replace if necessary
+    bool has_na = false;
+    for (int i = 0; i < col.size(); ++i) {
+      if (Rcpp::NumericVector::is_na(col[i])) {
+        has_na = true;
+        break;
+      }
+    }
+    if (has_na) {
+      Rcpp::NumericVector res = Rcpp::clone(col);
+      for (int i = 0; i < res.size(); ++i) {
+        if (Rcpp::NumericVector::is_na(res[i])) {
+          res[i] = default_val;
+        }
+      }
+      return res;
+    }
+    return col;
   }
   return Rcpp::NumericVector(df.nrow(), default_val);
 }


### PR DESCRIPTION
This change updates the `get_col_with_default` utility function in `src/utils.h` to handle `NA` values by replacing them with the provided default value. This ensures that censoring and truncation parameters (LC, LT, UC, UT) are correctly initialized even if the input data has missing values or is missing the columns entirely, maintaining backward compatibility. The corresponding TODO comment in `src/particle_ll.cpp` has been removed.

---
*PR created automatically by Jules for task [17097109098494374273](https://jules.google.com/task/17097109098494374273) started by @Howchie*